### PR TITLE
fixes to improve tests

### DIFF
--- a/src/MandMCounter.Core/Constants.cs
+++ b/src/MandMCounter.Core/Constants.cs
@@ -11,8 +11,8 @@ namespace MandMCounter.Core
         //Reference: this one thinks it's 0.625f http://www.answers.com/Q/What_is_a_volume_of_one_skittle
         //Reference 2: this one thinks it's  0.7418629f https://community.babycenter.com/post/a37375396/guess_how_many_skittles?cpg=2
         public const float SkittlesVolumeCubicCm = 0.7418629f; //Going with the bigger number, as skittles are bigger than M&Ms
-        //Reference: Volume of a jellybean is 3.5325, so the volume in one cubic CM is 1/3.5325 = 0.2831
-        public const float JellyBeansVolumeCubicCm = 0.2831f;
+        //Reference: Volume of a jellybean is 3.5325 cubic CM
+        public const float JellyBeansVolumeCubicCm = 3.5325f;
 
         //Reference: https://yenra.com/particle-packing/
         //Some people think this is 68.5%. https://cims.nyu.edu/~donev/Thesis.pdf

--- a/src/MandMCounter.Tests/JellyBeanTests.cs
+++ b/src/MandMCounter.Tests/JellyBeanTests.cs
@@ -19,7 +19,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, quantity);
 
             //Assert
-            Assert.AreEqual(8558f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(685.82, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -33,7 +33,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, quantity);
 
             //Assert
-            Assert.AreEqual(2140f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(171.46, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, quantity);
 
             //Assert
-            Assert.AreEqual(535f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(42.86, Math.Round(result, 2), 0.01);
         }
 
 
@@ -63,7 +63,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, quantity);
 
             //Assert
-            Assert.AreEqual(134f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(10.72, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -78,7 +78,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, quantity);
 
             //Assert
-            Assert.AreEqual(33f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(2.68, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, quantity);
 
             //Assert
-            Assert.AreEqual(11f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(0.89, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, quantity);
 
             //Assert
-            Assert.AreEqual(2260f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(181.17, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -136,7 +136,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(2260f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(181.17, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -153,7 +153,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(37f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(2.97, Math.Round(result, 2), 0.01);
         }
 
 
@@ -183,7 +183,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(1777f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(142.29, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -199,7 +199,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountJellyBeans(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(1862f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(149.23, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]

--- a/src/MandMCounter.Tests/MandMTests.cs
+++ b/src/MandMCounter.Tests/MandMTests.cs
@@ -19,7 +19,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(4047f, (float)System.Math.Round(result, 0), 0.1f);
+            Assert.AreEqual(4047.3, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -33,7 +33,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(1012f, (float)System.Math.Round(result, 0), 0.1f);
+            Assert.AreEqual(1011.82, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(32f, (float)System.Math.Round(result, 0), 0.1f);
+            Assert.AreEqual(31.62, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(339973f, (float)System.Math.Round(result, 0), 0.1f);
+            Assert.AreEqual(339972.88, Math.Round(result, 2), 0.01);
         }
 
 
@@ -76,7 +76,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(253f, (float)System.Math.Round(result, 0), 0.1f);
+            Assert.AreEqual(252.96, Math.Round(result, 2), 0.01);
         }
 
 
@@ -91,7 +91,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(63, (int)Math.Round(result, 0));
+            Assert.AreEqual(63.24, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(16, (int)Math.Round(result, 0));
+            Assert.AreEqual(15.81, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(5, (int)Math.Round(result, 0));
+            Assert.AreEqual(5.27, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(1069, (int)Math.Round(result, 0));
+            Assert.AreEqual(1069.18, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -160,7 +160,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(1069, (int)Math.Round(result, 0));
+            Assert.AreEqual(1069.18, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -176,7 +176,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(1069, (int)Math.Round(result, 0));
+            Assert.AreEqual(1069.18, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -192,7 +192,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(18, (int)Math.Round(result, 0));
+            Assert.AreEqual(17.52, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -208,7 +208,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(30276, (int)Math.Round(result, 0));
+            Assert.AreEqual(30275.94, Math.Round(result, 2), 0.01);
         }
 
 
@@ -229,7 +229,7 @@ namespace MandMCounter.Tests
             catch (Exception ex)
             {
                 //Assert
-                Assert.IsTrue(ex != null);
+                Assert.IsNotNull(ex);
             }
         }
 
@@ -245,7 +245,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(840, (int)Math.Round(result, 0));
+            Assert.AreEqual(839.73, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -260,7 +260,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(3359, (int)Math.Round(result, 0));
+            Assert.AreEqual(3358.94, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -275,7 +275,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(3359, (int)Math.Round(result, 0));
+            Assert.AreEqual(3358.94, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -290,7 +290,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(881, (int)Math.Round(result, 0));
+            Assert.AreEqual(880.69, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -305,7 +305,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountMandMs(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(95115, (int)Math.Round(result, 0));
+            Assert.AreEqual(95114.68, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -324,7 +324,7 @@ namespace MandMCounter.Tests
             catch (Exception ex)
             {
                 //Assert
-                Assert.IsTrue(ex != null);
+                Assert.IsNotNull(ex);
             }
         }
 

--- a/src/MandMCounter.Tests/PeanutMandMTests.cs
+++ b/src/MandMCounter.Tests/PeanutMandMTests.cs
@@ -20,7 +20,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(2892, (int)System.Math.Round(result, 0));
+            Assert.AreEqual(2891.83, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(1446, (int)System.Math.Round(result, 0));
+            Assert.AreEqual(1445.92, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(181, (int)System.Math.Round(result, 0));
+            Assert.AreEqual(180.74, Math.Round(result, 2), 0.01);
         }
 
 
@@ -66,7 +66,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(45, (int)Math.Round(result, 0));
+            Assert.AreEqual(45.18, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -81,7 +81,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(11, (int)Math.Round(result, 0));
+            Assert.AreEqual(11.3, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(4, (int)Math.Round(result, 0));
+            Assert.AreEqual(3.77, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, quantity);
 
             //Assert
-            Assert.AreEqual(764, (int)Math.Round(result, 0));
+            Assert.AreEqual(763.94, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -139,7 +139,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(764, (int)Math.Round(result, 0));
+            Assert.AreEqual(763.94, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -156,7 +156,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(13, (int)Math.Round(result, 0));
+            Assert.AreEqual(12.52, Math.Round(result, 2), 0.01);
         }
 
 
@@ -189,7 +189,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(600, (int)Math.Round(result, 0));
+            Assert.AreEqual(600, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -205,7 +205,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountPeanutMandMs(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(629, (int)Math.Round(result, 0));
+            Assert.AreEqual(629.26, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]

--- a/src/MandMCounter.Tests/SkittleTests.cs
+++ b/src/MandMCounter.Tests/SkittleTests.cs
@@ -19,7 +19,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, quantity);
 
             //Assert
-            Assert.AreEqual(3393f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(3393.21, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -33,7 +33,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, quantity);
 
             //Assert
-            Assert.AreEqual(848f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(848.3, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, quantity);
 
             //Assert
-            Assert.AreEqual(212f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(212.09, Math.Round(result, 2), 0.01);
         }
 
 
@@ -63,7 +63,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, quantity);
 
             //Assert
-            Assert.AreEqual(53f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(53.02, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -78,7 +78,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, quantity);
 
             //Assert
-            Assert.AreEqual(13f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(13.25, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, quantity);
 
             //Assert
-            Assert.AreEqual(4f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(4.42, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, quantity);
 
             //Assert
-            Assert.AreEqual(896f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(896.39, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -136,7 +136,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(896f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(896.39, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -153,7 +153,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, height, width, length);
 
             //Assert
-            Assert.AreEqual(15f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(14.69, Math.Round(result, 2), 0.01);
         }
 
 
@@ -185,7 +185,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(704f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(704.02, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]
@@ -201,7 +201,7 @@ namespace MandMCounter.Tests
             float result = Calculator.CountSkittles(unit, height, radius);
 
             //Assert
-            Assert.AreEqual(738f, System.Math.Round(result, 0), 1f);
+            Assert.AreEqual(738.36, Math.Round(result, 2), 0.01);
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request updates the volume constant for jelly beans and adjusts all related unit tests for jelly beans, M&Ms, and peanut M&Ms to use more precise expected values and improved assertion methods. The changes ensure that the calculations and tests are consistent with the corrected jelly bean volume and provide more accurate floating-point comparisons.